### PR TITLE
fix image upload

### DIFF
--- a/src/components/ImageComponent.js
+++ b/src/components/ImageComponent.js
@@ -2,6 +2,6 @@ import React from 'react';
 import { Entity } from 'draft-js';
 
 export default ({ block }) => {
-  const imgContent = Entity.get(block.getEntityAt(0)).getData()['preview'];
+  const imgContent = Entity.get(block.getEntityAt(0)).data.src;
   return <img src={imgContent} />;
 };

--- a/src/containers/RichEditor.js
+++ b/src/containers/RichEditor.js
@@ -5,7 +5,8 @@ import {
   Entity,
   RichUtils,
   ContentState,
-  CompositeDecorator
+  CompositeDecorator,
+  AtomicBlockUtils
 } from 'draft-js';
 import {
   getSelectionRange,
@@ -55,7 +56,7 @@ class RichEditor extends Component {
     this.toggleInlineStyle = (style) => this._toggleInlineStyle(style);
     this.insertImage = (file) => this._insertImage(file);
     this.blockRenderer = (block) => {
-      if (block.getType() === 'media') {
+      if (block.getType() === 'atomic') {
         return {
           component: ImageComponent
         };
@@ -111,9 +112,15 @@ class RichEditor extends Component {
   }
 
   _insertImage(file) {
-    this.setState({
+    /*this.setState({
       editorState: insertImage(this.state.editorState, file)
-    });
+    });*/
+    const entityKey = Entity.create('atomic', 'IMMUTABLE', {src: URL.createObjectURL(file)});
+		this.onChange(AtomicBlockUtils.insertAtomicBlock(
+        this.state.editorState,
+        entityKey,
+        ' '
+      ));
   }
 
   _handleFileInput(e) {


### PR DESCRIPTION
In Draft.js ^0.7.0, they offer simple method to handle media component inserted
this means we maybe no need to create custom fragment to handle it

This pull request would solve the error:
https://github.com/andrewcoelho/react-text-editor/issues/2
